### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/efm-ip-use-case.yml
+++ b/.github/workflows/efm-ip-use-case.yml
@@ -1,4 +1,6 @@
 name: Use case - TT02 & PROD
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/altinn-eformidling/security/code-scanning/1](https://github.com/Altinn/altinn-eformidling/security/code-scanning/1)

To fix the problem, add a `permissions:` block to the workflow that limits the job’s access to the minimum necessary. Since this workflow primarily performs code checkout (which only requires `contents: read`) and reports results externally (to Slack), it does not need write permissions to repository contents or other sensitive scopes. This change should be added at the top-level of the workflow file, just after the workflow name (making it apply to all jobs unless a job-specific block is used).

The best fix is to add the following snippet:
```yaml
permissions:
  contents: read
```
immediately after the workflow’s `name:` definition at the start of `.github/workflows/efm-ip-use-case.yml` (between lines 1 and 2).

No additional imports, method definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
